### PR TITLE
Add validation to latitude and longitude

### DIFF
--- a/app/Http/Requests/Call/StoreCallRequest.php
+++ b/app/Http/Requests/Call/StoreCallRequest.php
@@ -35,8 +35,8 @@ class StoreCallRequest extends FormRequest
             'commune_id'        => 'nullable|exists:communes,id',
             'address'           => 'nullable|string|min:0|max:255',
             'address_reference' => 'nullable|string|min:0|max:255',
-            'latitude'          => 'nullable|numeric',
-            'longitude'         => 'nullable|numeric',
+            'latitude'          => 'nullable|numeric|min:-90.00000000|max:90.00000000',
+            'longitude'         => 'nullable|numeric|min:-180.00000000|max:180.00000000',
             'sex' => [
                 'nullable',
                 Rule::in(['MALE', 'FEMALE', 'UNKNOWN', 'OTHER']),

--- a/database/migrations/2022_08_31_084223_update_precision_to_samu_calls.php
+++ b/database/migrations/2022_08_31_084223_update_precision_to_samu_calls.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('samu_calls', function (Blueprint $table) {
+            $table->decimal('longitude', 11, 8)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};


### PR DESCRIPTION
**Descripción**

**Data Type in Mysql: DECIMAL(M, D)**
```
DECIMAL(M, D)
```

**Donde:**

M nivel de Precisión en dígitos o el número total de dígitos para presentar un número, es decir:  números de dígitos de la parte entera +  números de dígitos  de la parte decimal.

D número de dígitos de la parte decimal

M - D = número de dígitos en la parte entera

Referencia : https://www.mysqldatatypes.com/#numeric

**Para la latitud requerimos un rango de:**
-99.99999999 a 99.99999999 porque la latitud va de -90 a 90

**Para la longitud requerimos un rango de:**
-999.99999999 999.99999999 porque la longitud va de -180 a 180

Referencia: https://docs.mapbox.com/help/glossary/lat-lon/

**Para ello definimos lo siguientes valores:**

**Latitud**
M = 10
D = 8

Siendo M el número de dígitos que puede soportar el campo.

M - D = 10 - 8 = 2 dígitos para la parte entera

Entonces D = 8 para dígitos para representar la parte decimal

En conclusion: M = 10 dígitos a soportar de la latitud +-99.99999999
Donde M - D = 2 dígitos para la parte entera y D = 8 dígitos para la parte decimal.

**Longitud**
M = 11
D = 8

Siendo M el número de dígitos que puede soportar el campo.

M - D = 11 - 8 = 3 dígitos para representar la parte entera

Entonces D = 8 dígitos para representar la parte decimal.

En conclusion: M = 11 dígitos a soportar de la latitud +-999.99999999
Donde M - D = 2 dígitos para la parte entera y D = 8 dígitos para la parte decimal.

Referencia: https://parzibyte.me/blog/2017/09/22/entendiendo-tipo-dato-decimal-en-mysql/

**Decimales**
Por otra parte, decimos que 8 dígitos para la parte decimal en la latitud y longitud
ya que con 8 decimales solo hay un margen de error 1.11 mm de distancia.

Referencia http://wiki.gis.com/wiki/index.php/Decimal_degrees

**Actualizaciones**
Por ende actualizamos el M del campo longitude (migrations)

Longitude ```DECIMAL(11, 8)```


**Agregamos validaciones a latitud y longitud en StoreCallRequest**
```
'latitude'          => 'nullable|numeric|min:-90.00000000|max:90.00000000',
'longitude'         => 'nullable|numeric|min:-180.00000000|max:180.00000000',
```

Hace referencia al issue #8 
